### PR TITLE
Add JSON file saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,11 @@ Crystal tools <br>
 ![Preview](https://i.gyazo.com/dc858c9708d3da4eb2f5fdcc73d424b5.png)
 
 
-## Ability to save as JSON 
-Button on UI will allow user to swap to use JSON. 
+## Ability to save as JSON
+Previous entries in normal data entry will not be added to a json file, as we do not know when they were used.
+Will save all data according to the date that they were used. This can further expand to the UI panel of the plugin to show what was just used during a certain timespan.
 
-All previous entries will not have a date associated with it, as it is not possible to know. Anything that happened in the session may get the current time and date. 
-This will also save differently into JSON files. Each object in the JSON file will be:
 
-Items:
-	Item:
-		Name:
-		Consumed_time
 		
 
 		

--- a/README.md
+++ b/README.md
@@ -34,8 +34,3 @@ Crystal tools <br>
 ## Ability to save as JSON
 Previous entries in normal data entry will not be added to a json file, as we do not know when they were used.
 Will save all data according to the date that they were used. This can further expand to the UI panel of the plugin to show what was just used during a certain timespan.
-
-
-		
-
-		

--- a/README.md
+++ b/README.md
@@ -29,3 +29,18 @@ Crystal tools <br>
 *preview has weapon charges enabled and disabled to show both styles*
 
 ![Preview](https://i.gyazo.com/dc858c9708d3da4eb2f5fdcc73d424b5.png)
+
+
+## Ability to save as JSON 
+Button on UI will allow user to swap to use JSON. 
+
+All previous entries will not have a date associated with it, as it is not possible to know. Anything that happened in the session may get the current time and date. 
+This will also save differently into JSON files. Each object in the JSON file will be:
+
+Items:
+	Item:
+		Name:
+		Consumed_time
+		
+
+		

--- a/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerConfig.java
@@ -65,4 +65,14 @@ public interface SuppliesTrackerConfig extends Config
 	{
 		return false;
 	}
+
+	@ConfigItem(
+		keyName = "jsonEnabled",
+		name = "Save data as json",
+		description = "Save data in a json format."
+	)
+	default boolean jsonEnabled()
+	{
+		return false;
+	}
 }

--- a/src/main/java/com/suppliestracker/SuppliesTrackerItemJson.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerItemJson.java
@@ -24,6 +24,15 @@
  */
 package com.suppliestracker;
 
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.TypeAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -39,5 +48,25 @@ public class SuppliesTrackerItemJson
 	private String name;
 	private int quantity;
 	private long price;
-	private Date usedTime;
+	private ZonedDateTime usedTime;
+
+	public String toJson()
+	{
+		Gson gson = new GsonBuilder()
+			.registerTypeAdapter(ZonedDateTime.class, new TypeAdapter<ZonedDateTime>() {
+				@Override
+				public void write(JsonWriter out, ZonedDateTime value) throws IOException {
+					out.value(value.toString());
+				}
+
+				@Override
+				public ZonedDateTime read(JsonReader in) throws IOException {
+					return ZonedDateTime.parse(in.nextString());
+				}
+			})
+			.enableComplexMapKeySerialization()
+			.setFieldNamingPolicy(FieldNamingPolicy.IDENTITY)
+			.create();
+		return gson.toJson(this);
+	}
 }

--- a/src/main/java/com/suppliestracker/SuppliesTrackerItemJson.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerItemJson.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2018, Daddy Dozer <https://github.com/Dyldozer>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package com.suppliestracker;
+
+import java.util.Date;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter(AccessLevel.PUBLIC)
+@Setter(AccessLevel.PUBLIC)
+@AllArgsConstructor
+public class SuppliesTrackerItemJson
+{
+	private int id;
+	private String name;
+	private int quantity;
+	private long price;
+	private Date usedTime;
+}

--- a/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
+++ b/src/main/java/com/suppliestracker/SuppliesTrackerPlugin.java
@@ -34,7 +34,10 @@ import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.ArrayDeque;
+import java.util.Date;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
@@ -1354,6 +1357,19 @@ public class SuppliesTrackerPlugin extends Plugin
 		{
 			sessionHandler.addToSession(itemId, count, false);
 			currentSuppliesEntry.put(itemId, newEntryC);
+		}
+
+		if(config.jsonEnabled())
+		{
+			SimpleDateFormat formatter = new SimpleDateFormat("dd/MM/yyyy HH:mm:ss");
+			Date date = new Date();
+			SuppliesTrackerItemJson jsonItem = new SuppliesTrackerItemJson(
+				itemId,
+				name,
+				newQuantityC,
+				calculatedPrice * newQuantityC,
+				date
+			);
 		}
 
 		SwingUtilities.invokeLater(() -> panel.addItem(showSession ? newEntryC : newEntry));

--- a/src/main/java/com/suppliestracker/session/SessionHandler.java
+++ b/src/main/java/com/suppliestracker/session/SessionHandler.java
@@ -1,6 +1,13 @@
 package com.suppliestracker.session;
 
 import com.google.inject.Inject;
+import com.suppliestracker.SuppliesTrackerItemJson;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import jdk.vm.ci.meta.Local;
 import net.runelite.api.Client;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -82,6 +89,31 @@ public class SessionHandler
 			{
 				i.printStackTrace();
 			}
+
+		}
+		catch (IOException e)
+		{
+			e.printStackTrace();
+		}
+	}
+
+	public void addNewRecordToJson(SuppliesTrackerItemJson json)
+	{
+		try
+		{
+			File jsonDir = new File(RUNELITE_DIR + "/supplies-tracker/json");
+			jsonDir.mkdir();
+
+			DateTimeFormatter timeStampPattern = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+			File sessionFile = new File(RUNELITE_DIR + "/supplies-tracker/json/" + timeStampPattern.format(java.time.LocalDateTime.now()) + ".log");
+
+			sessionFile.createNewFile();
+
+			Writer writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(sessionFile, true), "UTF-8"));
+			writer.append(json.toJson());
+			writer.append("\n");
+			writer.flush();
+			writer.close();
 
 		}
 		catch (IOException e)


### PR DESCRIPTION
Adds the ability for users to save their data as JSON, in addition to normal saving. This can further enable more additions to this plugin, or combining with our plugins to see true supplies used vs loot gathered.